### PR TITLE
feat(parser): Added custom logger option

### DIFF
--- a/example/parser/index.ts
+++ b/example/parser/index.ts
@@ -2,9 +2,9 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import jsPDF from 'jspdf';
-import { Parser } from '../../src';
+import { type MdImgRemoteRequestor, MdParser } from '../../src';
 
-const remoteRequestor = async (url: string, method: string) => {
+const remoteRequestor: MdImgRemoteRequestor = async (url, method) => {
   const request = await fetch(url, { method });
 
   return {
@@ -27,7 +27,7 @@ const runOnFile = async (file: string) => {
   });
 
   // Parse Markdown
-  const parser = new Parser(md);
+  const parser = new MdParser(md);
   const doc = await parser.parse();
 
   // Load images

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const mdToPDF = async (
     remoteRequestor,
     assetDir,
     margin,
+    logger,
     ...renderOpts
   } = opts || {};
 
@@ -51,7 +52,7 @@ const mdToPDF = async (
   };
 
   // Parse Markdown
-  const parser = new Parser(md);
+  const parser = new Parser(md, logger);
   const doc = await parser.parse();
 
   // Load images

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import type jsPDF from 'jspdf';
 import type { PluginOptions, MarginOption } from './jspdf'; // extended types
 
+import type { ImgRemoteRequestor } from './markdown/elements/Img';
 import Parser from './markdown/Parser';
 
-const defaultRemoteRequestor = async (url: string, method: string) => {
+const defaultRemoteRequestor: ImgRemoteRequestor = async (url: string, method: string) => {
   const request = await fetch(url, { method });
 
   return {
@@ -97,6 +98,11 @@ try {
 
 export default mdToPDF;
 export {
+  /** * @deprecated use `MdParser` instead  */
   Parser,
+  Parser as MdParser,
+  /** * @deprecated use `MdParserOptions` instead  */
   PluginOptions,
+  PluginOptions as MdParserOptions,
+  ImgRemoteRequestor as MdImgRemoteRequestor,
 };

--- a/src/jspdf.d.ts
+++ b/src/jspdf.d.ts
@@ -15,7 +15,11 @@ export type PluginOptions = RenderOptions & {
   /**
    * Margin between markdown and limit of page
    */
-  margin?: number | MarginOption
+  margin?: number | MarginOption,
+  /**
+   * Logger used by parser to send not critical messages
+   */
+  logger?: Console,
 };
 
 declare module 'jspdf' {

--- a/src/markdown/Parser.ts
+++ b/src/markdown/Parser.ts
@@ -1,4 +1,3 @@
-import { warn } from 'console';
 import { marked } from 'marked';
 
 import * as Md from './elements';
@@ -8,7 +7,7 @@ export default class Parser<T = never> extends marked.Renderer<T> {
 
   private imagesToLoad: Md.ImgElement['load'][] = [];
 
-  constructor(private data: string) {
+  constructor(private data: string, private logger = console) {
     super();
   }
 
@@ -69,7 +68,7 @@ export default class Parser<T = never> extends marked.Renderer<T> {
 
   // eslint-disable-next-line class-methods-use-this
   html(_html: string) {
-    warn("HTML in MD isn't supported");
+    this.logger.warn("HTML in MD isn't supported");
     return '';
   }
 

--- a/src/markdown/elements.ts
+++ b/src/markdown/elements.ts
@@ -4,7 +4,7 @@ export { default as HrElement } from './elements/Hr';
 export { default as BrElement } from './elements/Br';
 export { default as CheckboxElement } from './elements/Checkbox';
 
-export { default as ImgElement } from './elements/Img';
+export { default as ImgElement, ImgRemoteRequestor } from './elements/Img';
 export { default as CodeSpanElement } from './elements/CodeSpan';
 export { default as CodeElement } from './elements/Code';
 export { default as TextElement } from './elements/Text';


### PR DESCRIPTION
You can now use custom logger instead of console one (still the default)

Also prefixed index import with `Md` (so `Parser` became `MdParser`) and marked as deprecated unprefixed ones